### PR TITLE
Add /sse alias for SSE endpoint

### DIFF
--- a/perplexity-ask/README-SSE.md
+++ b/perplexity-ask/README-SSE.md
@@ -60,8 +60,9 @@ Returns server status and configuration.
 ### 2. SSE Events
 ```
 GET /mcp/events
+GET /sse (alias)
 ```
-Server-Sent Events endpoint for real-time communication.
+Server-Sent Events endpoint for real-time communication. Both paths are supported for compatibility.
 
 ### 3. List Tools
 ```
@@ -189,7 +190,7 @@ To integrate this MCP server with your application using SSE:
 
 1. **Connect to SSE endpoint**:
 ```javascript
-const eventSource = new EventSource('http://localhost:3000/mcp/events');
+const eventSource = new EventSource('http://localhost:3000/mcp/events'); // '/sse' is also supported
 ```
 
 2. **Listen for events**:

--- a/perplexity-ask/client-example.html
+++ b/perplexity-ask/client-example.html
@@ -156,6 +156,7 @@
                 eventSource.close();
             }
             
+            // Connect to SSE endpoint (/mcp/events or legacy /sse)
             eventSource = new EventSource(`${serverUrl}/mcp/events`);
             
             eventSource.onopen = function() {

--- a/perplexity-ask/dist/index.js
+++ b/perplexity-ask/dist/index.js
@@ -276,8 +276,8 @@ class HttpServerTransport {
         this.app.get("/health", (req, res) => {
             res.json({ status: "ok", transport: "http", port: this.port });
         });
-        // SSE endpoint for MCP communication
-        this.app.get("/mcp/events", (req, res) => {
+        // SSE endpoint for MCP communication (supports legacy /sse path)
+        this.app.get(["/mcp/events", "/sse"], (req, res) => {
             res.writeHead(200, {
                 "Content-Type": "text/event-stream",
                 "Cache-Control": "no-cache",
@@ -588,7 +588,7 @@ class HttpServerTransport {
             return new Promise((resolve) => {
                 this.app.listen(this.port, () => {
                     console.error(`Perplexity MCP Server running on HTTP port ${this.port}`);
-                    console.error(`SSE endpoint: http://localhost:${this.port}/mcp/events`);
+                    console.error(`SSE endpoint: http://localhost:${this.port}/mcp/events (alias: /sse)`);
                     console.error(`Health check: http://localhost:${this.port}/health`);
                     console.error(`Tools endpoint: http://localhost:${this.port}/mcp/tools`);
                     console.error(`Call endpoint: http://localhost:${this.port}/mcp/call`);

--- a/perplexity-ask/index.ts
+++ b/perplexity-ask/index.ts
@@ -300,8 +300,8 @@ class HttpServerTransport {
       res.json({ status: "ok", transport: "http", port: this.port });
     });
 
-    // SSE endpoint for MCP communication
-    this.app.get("/mcp/events", (req: Request, res: Response) => {
+    // SSE endpoint for MCP communication (supports legacy /sse path)
+    this.app.get(["/mcp/events", "/sse"], (req: Request, res: Response) => {
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -611,7 +611,9 @@ class HttpServerTransport {
     return new Promise<void>((resolve) => {
       this.app.listen(this.port, () => {
         console.error(`Perplexity MCP Server running on HTTP port ${this.port}`);
-        console.error(`SSE endpoint: http://localhost:${this.port}/mcp/events`);
+        console.error(
+          `SSE endpoint: http://localhost:${this.port}/mcp/events (alias: /sse)`
+        );
         console.error(`Health check: http://localhost:${this.port}/health`);
         console.error(`Tools endpoint: http://localhost:${this.port}/mcp/tools`);
         console.error(`Call endpoint: http://localhost:${this.port}/mcp/call`);


### PR DESCRIPTION
## Summary
- support `/sse` as an alias for `/mcp/events`
- document SSE alias in README-SSE and client example

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855ce49bbdc833099f039386af28f6c